### PR TITLE
Test against porter v1.0.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Porter
         run: |
-          curl -fsSLo porter "https://cdn.porter.sh/v1.0.1/porter-linux-amd64"
+          curl -fsSLo porter "https://cdn.porter.sh/v1.0.9/porter-linux-amd64"
           chmod +x porter
 
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Porter
         run: |
-          curl -fsSLo porter "https://cdn.porter.sh/v1.0.1/porter-linux-amd64"
+          curl -fsSLo porter "https://cdn.porter.sh/v1.0.9/porter-linux-amd64"
           chmod +x porter
 
       - name: Test


### PR DESCRIPTION
Update our github workflows to use the latest version of porter